### PR TITLE
Add handling of entire Twitter data archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ The Keybase comparisons are done by calling `$ keybase id [username]@twitter` fr
 Keybase needs to be [installed locally](https://keybase.io/download) since the script makes use of a keybase command-line call to work. 
 
 #### Twitter list of users
-Your respective Twitter list can be gotten by ["requesting your data"](https://help.twitter.com/en/managing-your-account/how-to-download-your-twitter-archive) under your Twitter settings. Specifically, the `followers.j` and `following.js` files are what this script is designed to work with from the bundle that Twitter returns.
+Your respective Twitter list can be gotten by ["requesting your data"](https://help.twitter.com/en/managing-your-account/how-to-download-your-twitter-archive) under your Twitter settings. Specifically, the `follower.js` and `following.js` files are what this script is designed to work with from the bundle that Twitter returns.
 
 ## To run
-Simply uncompress your downloaded Twitter personal data archive, and add only the files `followers.j` and `following.j` to the `data` folder, and then run `run.py` using:
+Simply add the downloaded `.zip` archive as-is to the `/data` folder, and then run `run.py` using:
 `$ python3 run.py`
+
+>Note: for a more selective comparison you can also place either the `follower.js` or `following.js` files, or any one or more `.js` files into the `/data` folder once they are in the same format as the `follower.js`/`following.js` files.

--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ Keybase needs to be [installed locally](https://keybase.io/download) since the s
 Your respective Twitter list can be gotten by ["requesting your data"](https://help.twitter.com/en/managing-your-account/how-to-download-your-twitter-archive) under your Twitter settings. Specifically, the `followers.j` and `following.js` files are what this script is designed to work with from the bundle that Twitter returns.
 
 ## To run
-Simply place your Twitter user file into the `data` folder and then run `run.py` using:
+Simply uncompress your downloaded Twitter personal data archive, and add only the files `followers.j` and `following.j` to the `data` folder, and then run `run.py` using:
 `$ python3 run.py`

--- a/run.py
+++ b/run.py
@@ -3,6 +3,7 @@ import re, ast
 import os, sys, shutil
 from subprocess import call
 import json, time
+from zipfile import ZipFile, is_zipfile
 
 # Files
 folders = [r'results', r'results/temp']

--- a/run.py
+++ b/run.py
@@ -12,9 +12,22 @@ for f in folders:
 
 # find the data file, assign to 'dataIn' variable
 allFiles = []
+filesToExtract = ['following.js', 'follower.js']
+zipFound = False
 for filename in os.listdir('data'):
-    if '.js' in filename:
-        allFiles.append(filename)
+    if is_zipfile(filename):
+        zipFound = True
+        with ZipFile(filename, 'r') as unzipped:
+            for f in filesToExtract:                
+                try:                
+                    unzipped.extract(f)
+                    allFiles.append(f)
+                except KeyError:
+                    pass
+if not(zipFound):
+    for filename in os.listdir('data'):
+        if '.js' in filename:
+            allFiles.append(filename)
 
 
 # set the results file

--- a/run.py
+++ b/run.py
@@ -13,12 +13,14 @@ for f in folders:
 
 # find the data file, assign to 'dataIn' variable
 allFiles = []
+datadir = 'data'
 filesToExtract = ['following.js', 'follower.js']
 zipFound = False
-for filename in os.listdir('data'):
-    if is_zipfile(filename):
+for filename in os.listdir(datadir):
+    fileAtLocation = f"{datadir}/{filename}"
+    if is_zipfile(fileAtLocation):
         zipFound = True
-        with ZipFile(filename, 'r') as unzipped:
+        with ZipFile(fileAtLocation, 'r') as unzipped:
             for f in filesToExtract:                
                 try:                
                     unzipped.extract(f)
@@ -26,7 +28,7 @@ for filename in os.listdir('data'):
                 except KeyError:
                     pass
 if not(zipFound):
-    for filename in os.listdir('data'):
+    for filename in os.listdir(datadir):
         if '.js' in filename:
             allFiles.append(filename)
 
@@ -57,7 +59,7 @@ def getData(readFile):
 dataIn = []
 try:
     for f in allFiles:
-        datafile = 'data/' + f
+        datafile = f"{datadir}/{f}"
         dataIn.extend(getData(datafile))
 except NameError:
     print("Error: Data file is missing from 'data/' directory.")

--- a/run.py
+++ b/run.py
@@ -23,7 +23,7 @@ for filename in os.listdir(datadir):
         with ZipFile(fileAtLocation, 'r') as unzipped:
             for f in filesToExtract:                
                 try:                
-                    unzipped.extract(f)
+                    unzipped.extract(f, datadir)
                     allFiles.append(f)
                 except KeyError:
                     pass

--- a/run.py
+++ b/run.py
@@ -133,7 +133,7 @@ def fetchUsername(allUserIDs):
             if timeout == 0:
                 print(f"{warn}{len(allUsernames)+1} of {count}: userID #{userid} failed{_end}")
             else:
-                print(end="\033[F" * 4)
+                print(end="\033[F" * 5)
 
             timeout += 1
             allUserIDs.insert(0, userid)


### PR DESCRIPTION
Instead of having to extract and move the follower/following files, this change would allow the user to simply place the entire `.zip` file into the data folder for processing.